### PR TITLE
Fix string value for yesno setting in config.xml

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -7,7 +7,7 @@
                 <title>ParcelPro</title>
                 <sallowspecific>0</sallowspecific>
                 <model>Parcelpro\Shipment\Model\Carrier\Parcelpro</model>
-                <auto>Automatisch aanmelden</auto>
+                <auto>0</auto>
                 <postnl_title>PostNL versturen via parcelpro.nl</postnl_title>
                 <dhl_title>DHL versturen via parcelpro.nl</dhl_title>
                 <specificerrmsg>This shipping method is not available. To use this shipping method, please contact us.</specificerrmsg>


### PR DESCRIPTION
the `auto` setting has a yesno source model, a string value is thus invalid.