### PR TITLE
Fix Intrapost orders...

### DIFF
--- a/Controller/Adminhtml/Order/UpdateOrder.php
+++ b/Controller/Adminhtml/Order/UpdateOrder.php
@@ -46,7 +46,7 @@ class UpdateOrder extends \Magento\Backend\App\Action
         }
 
         // Controleren of de zending al is aangemeld.
-        if ($pp_result && $pp_result["barcode"] != "") {
+        if ($pp_result && $pp_result['id']) {
             $this->messageManager->addErrorMessage(__("Actie niet mogelijk: zending al aangemeld."));
             $this->_redirect($this->_redirect->getRefererUrl());
             return;

--- a/Observer/Shipment.php
+++ b/Observer/Shipment.php
@@ -127,7 +127,10 @@ class Shipment implements ObserverInterface
                             throw new LocalizedException(__(sprintf("De zending is niet succesvol aangemeld bij ParcelPro foutcode: %s, melding: %s", $response_code, $response_body['omschrijving']), 10));
                         }
 
-                        if (isset($response_body['Barcode'])) {
+                        $carrier = $response_body['Carrier'];
+                        $data = ['zending_id' => $response_body['Id'], 'order_id' => $order_id, 'carrier' => $carrier, 'label_url' => $response_body['LabelUrl']];
+
+                        if (isset($response_body['Barcode']) && $response_body['Barcode']) {
                             $firstTwoCharOfBarcode = substr($response_body['Barcode'], 0, 2);
                             $carrier = false;
                             if (isset($shipping_title) && array_key_exists($shipping_title, $config)) {
@@ -139,17 +142,15 @@ class Shipment implements ObserverInterface
                                     $carrier = "PostNL via Parcel Pro";
                                 } elseif ($firstTwoCharOfBarcode === "JJ") {
                                     $carrier = "DHL via Parcel Pro";
-                                } else {
-                                    $carrier = $response_body['Carrier'];
                                 }
                             }
 
                             $data = ['zending_id' => $response_body['Id'], 'order_id' => $order_id, 'barcode' => $response_body['Barcode'], 'carrier' => $carrier, 'url' => $response_body['TrackingUrl'], 'label_url' => $response_body['LabelUrl']];
-
-                            $parcelproModel = $this->_modelParcelproFactory->create();
-                            $parcelproModel->setData($data);
-                            $parcelproModel->save();
                         }
+
+                        $parcelproModel = $this->_modelParcelproFactory->create();
+                        $parcelproModel->setData($data);
+                        $parcelproModel->save();
                     }
                 }
             }

--- a/Plugin/PluginBefore.php
+++ b/Plugin/PluginBefore.php
@@ -33,7 +33,7 @@ class PluginBefore
                 $result = $result[count($result) - 1];
             }
 
-            if ($result && !is_null($result["barcode"])) {
+            if ($result && $result['id']) {
                 $buttonList->add(
                     'print_label',
                     ['label' => __('Print label'), 'onclick' => 'setLocation(\'' . $context->getUrl("pp_shipment/shipment/printlabel") . '\')', 'class' => 'save'],


### PR DESCRIPTION
- https://app.clickup.com/t/86bza873b
- Print Label-knop tonen, checken op basis van id en niet barcode, want Intrapost is geen zelfbouw
- Ik kreeg problemen met het opslaan van een order van Intrapost in de tabel 'parcelpro_shipments' (in Magento), komt denk ik door 'Barcode' en 'TrackingUrl' die wel set zijn, maar NULL zijn bij Intrapost.